### PR TITLE
添加 QSELM CPU 原生语言模型训练框架

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,11 @@
     ![](https://img.shields.io/github/stars/Tongjilibo/bert4torch.svg)
   * 简介：该项目提供了一个大模型的训练和部署框架，包含了目前主要的开源大模型，llama系列，chatglm，bloom系列等等，同时还给出了预训练和微调的示例。
 
+* QSELM（CPU Native LM Train）：
+  
+  * 地址：https://github.com/shyringo/cpu-native-lm-train
+    ![](https://img.shields.io/github/stars/shyringo/cpu-native-lm-train.svg)
+  * 简介：面向普通 CPU 与系统内存、无需独立显卡的原创稀疏语言模型与训练框架，发布了 3408.7 万参数的 QSELM v0.1 模型包、训练与生成 CLI 以及可复现实验。在 Intel Core i5-1340P、32 GB 内存上的完整训练吞吐为 215,771 token/s，是本机官方 Qwen 计算图最快实测的 8529 倍；还提供从约 2000 token 长文档中检索和组合事实、以及让 Agent 跨轮次保存并调用事实的封存评测。项目明确限定这些是窄任务结果，尚不代表通用 Agent 或自由文本生成优于 Transformer。
 ### 5. LLM推理部署框架
 
 * vLLM：

--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@
   * 地址：https://github.com/shyringo/cpu-native-lm-train
     ![](https://img.shields.io/github/stars/shyringo/cpu-native-lm-train.svg)
   * 简介：面向普通 CPU 与系统内存、无需独立显卡的原创稀疏语言模型与训练框架，发布了 3408.7 万参数的 QSELM v0.1 模型包、训练与生成 CLI 以及可复现实验。在 Intel Core i5-1340P、32 GB 内存上的完整训练吞吐为 215,771 token/s，是本机官方 Qwen 计算图最快实测的 8529 倍；还提供从约 2000 token 长文档中检索和组合事实、以及让 Agent 跨轮次保存并调用事实的封存评测。项目明确限定这些是窄任务结果，尚不代表通用 Agent 或自由文本生成优于 Transformer。
+
 ### 5. LLM推理部署框架
 
 * vLLM：


### PR DESCRIPTION
## 变更内容

在“4. LLM训练微调框架”中添加 QSELM（CPU Native LM Train）。条目沿用现有的“项目名 + 地址 + Star 徽章 + 简介”格式。

## 为什么适合本列表

QSELM 是面向普通 CPU 与系统内存、无需独立显卡的 3408.7 万参数稀疏语言模型与训练框架，仓库提供中英双语文档、可下载模型包、训练与生成 CLI，以及可复现实验。它直接服务于本列表关注的低门槛本地 LLM 训练。

条目保留了关键实测数字，也写明结论边界：8,529 倍是指定机器与完整计时口径下相对官方 Qwen 计算图的训练吞吐结果；长文档推理与 Agent 持久记忆是封存的窄任务评测，不代表通用 Agent 或自由文本生成优于 Transformer。

## 提交前检查

- 已检查 README 和开放 PR，没有重复条目
- 仅修改 README.md，增加一个条目
- 链接、数字及结论边界均可在项目 README 和正式报告中核验

披露：我是被收录项目的维护者。