### PR TITLE
添加 China AI Model Index 到第8节相关仓库

### DIFF
--- a/README.md
+++ b/README.md
@@ -1312,6 +1312,12 @@
     ![](https://img.shields.io/github/stars/nowork-studio/awesome-ai-startups.svg)
   * 简介：独立开发者创建的 AI 创业产品精选列表，涵盖自筹资金、种子轮前和天使轮融资的产品。
 
+* China AI Model Index：
+  
+  * 地址：https://github.com/jasoncrinews-del/china-ai-model-index
+    ![](https://img.shields.io/github/stars/jasoncrinews-del/china-ai-model-index.svg)
+  * 简介：该项目整理了 21 家中国大模型厂商的 69 个模型发布记录，包含发布日期、参数量与激活参数、上下文窗口、开放方式、许可证与已公开的 API 价格。每个字段都附一手来源 URL 与核验日期，厂商未公开的字段留空而不估算；提供 CSV 与 JSON 两种格式，每日自动同步，数据以 CC-BY-4.0 发布。
+
 ## Star History
 
 <a href="https://star-history.com/#AiHubCN/Awesome-Chinese-LLM&Date">


### PR DESCRIPTION
在「8. 相关仓库」补充一个带一手来源的中国大模型规格索引，格式与该节现有条目（LLMs-In-China、BMList、LLM-Zoo）一致。

**仓库**：https://github.com/jasoncrinews-del/china-ai-model-index

与该节已有项目互补的地方在于**可核验性**：

- 21 家厂商、69 个发布记录，覆盖发布日期、总参数与激活参数、上下文窗口、开放方式、许可证、已公开的 API 价格
- 每条记录附一手来源 URL（共 181 个）与核验日期 `lastVerifiedAt`，可以直接判断某个数字是什么时候、依据什么写下的
- 厂商未公开的字段**留空而不估算**（69 条里有 38 条没有激活参数，因为厂商没披露）
- CSV 与 JSON 两种格式，`scripts/refresh.py` 无需任何凭据即可自行拉取当前快照
- GitHub Actions 每日同步上游，不是一次性快照
- 数据 CC-BY-4.0，代码 MIT

条目描述的长度或措辞需要调整的话，我随时可以改。