### PR TITLE
数据集：中国法律法规与案例结构化语料库（CC0）

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,12 @@
 
 #### 预训练数据集
 
+* chinese-law-corpus
+  
+  * 地址：https://github.com/lttxzmj/chinese-law-corpus
+    ![](https://img.shields.io/github/stars/lttxzmj/chinese-law-corpus.svg)
+  * 数据集说明：中国法律法规与案例结构化语料库（CC0）：412部现行有效法律与司法解释逐条结构化JSON（2.6万+条，带效力状态与公布/施行日期，官方来源逐部人工核对），278件最高法指导性案例（裁判要点/案情/理由分字段）与445件《最高人民法院公报》案例文书。条文使用稳定ID（如civil-code-0577），适合法律RAG、检索基准与引用溯源生成，数据持续维护更新。
+
 * MNBVC
   
   * 地址：https://github.com/esbatmop/MNBVC


### PR DESCRIPTION
在「数据集/预训练数据集」新增 chinese-law-corpus：412 部现行法律/司法解释逐条 JSON + 278 指导性案例 + 445 公报案例文书，CC0 释出可自由商用。条文稳定 ID 天然适配法律 RAG 的 chunk 边界与引用溯源；官方来源逐部人工核对，法律季度更新。与本列表已收录的法律 LLM 项目（LaWGPT、DISC-LawLLM 等）互补，可直接作其检索底座。